### PR TITLE
Move virtualenv into an own layer, speedup building&launching

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,18 +9,23 @@ RUN apt-get update \
 # These can be added to apt-get install, if needed: python-cv-bridge and ros-melodic-cv-bridge
 
 # WORDKIR will create and set the current working directory.
-# poetry needs to be run from this directory, with the pyproject.toml and poetry.lock files inside it.
-WORKDIR /catkin_ws/src/ohtu
-COPY . /catkin_ws/src/ohtu
+# Create python virtualenv in own layer, to speed up building containers
+WORKDIR /catkin_ws/src/ohtu/rostest
+COPY pyproject.toml poetry.lock /catkin_ws/src/ohtu/
 RUN python3.7 -m pip install --upgrade pip \
  && python3.7 -m pip install poetry \
  && poetry run pip install --upgrade pip \
  && poetry run pip install --upgrade setuptools \
  && poetry install
+
+# Own layer for the project, NOTE: this folder (rostest/) should be changed, when the project name changes (in the repo).
+# We need to create our own directory here, since docker COPY srcdic destdir actually works like COPY srcdir/* destdir
+COPY rostest/ /catkin_ws/src/ohtu/rostest/
 WORKDIR /catkin_ws
 RUN /bin/bash -c "source /opt/ros/melodic/setup.bash && catkin_make"
 
 
+# Can we omit the sourcing from these layers?
 FROM rosbase as rostest
 CMD cd /catkin_ws/src/ohtu && poetry run /bin/bash -c 'source /opt/ros/melodic/setup.bash && source ../../devel/setup.bash && cd rostest && rosrun rostest main.py'
 


### PR DESCRIPTION
Projektin rakenteesta johtuen sekä dockerin toiminnallisuuden vuoksi joudutaan luomaan rostest -kansio "manuaalisesti" rivillä 13. Jos kellään ei ole parempaa tapaa tiedossa, niin tämä olisi syytä muistaa ja sitten muuttaa kun mergetään issueta [85](https://github.com/Konenako/Ohtuprojekti-kesa2020/issues/85).