### PR TITLE
Map sort filter detections

### DIFF
--- a/src/scripts/node_detector_control.py
+++ b/src/scripts/node_detector_control.py
@@ -49,47 +49,57 @@ class DetectorControlNode:
         self.detect_lock.release()
         return srv.add_object_detectorResponse()
 
+    ## Publishes image observations by calling helper functions
+    #  Observations can be published separately or combined
     def receive_img(self, msg: image):
+        # Call helper function depending on boolean
+        if self.combine:
+            self.publish_combined(msg)
+        else:
+            self.publish_separately(msg)        
+
+    ## Helper function for publishing observations.
+    #  Iterates trough all detectors and publishes the
+    #  observations directly.
+    #  Locks self.detect_lock for iterating the dict.
+    def publish_separately(self, msg: image) -> None:
+        img = msg_to_cv2(msg)[2]
+        
+        self.detect_lock.acquire()
+        for node in self.detectors.values():
+            obs = tuple(node.receive_img(img))
+            # Dont publish empty observations
+            if not obs: continue
+
+            self.pub.publish(
+                observations(msg.camera_id, msg.image_counter, obs)
+            )
+        self.detect_lock.release()
+
+    ## Helper function for publishing observations.
+    #  Maps all detectors results before processing the observations.
+    #  and finally publishes them all in one message.
+    #  Locks self.detect_lock while mapping the detections.
+    def publish_combined(self, msg: image) -> None:
         img = msg_to_cv2(msg)[2]
 
-        # Get observations from all active nodes
         self.detect_lock.acquire()
         observations_mapobj =  map(
             lambda node: node.receive_img(img), self.detectors.values()
         )
         self.detect_lock.release()
         
-
-        # If combining is off, each node publishes the results separately.
-        if not self.combine:
-            for obs in observations_mapobj:
-                obs = tuple(obs)
-                if not obs:
-                    # Dont publish empty observations
-                    continue
-
-                self.pub.publish(
-                    observations(msg.camera_id, msg.image_counter, obs)
-                )
-            return
-        
-        
-        # If combining is on, publish all the results at once.
-
         # Flatten observations for combined observations message
-        obser = (obs for observations_mapobj in observations_mapobj for obs in observations_mapobj)
-        
-        obser = tuple(obser)
+        obs = (obs for observations_mapobj in observations_mapobj for obs in observations_mapobj)
+        obs = tuple(obs)
 
         # Dont publish empty observations
-        if not obser:
+        if not obs:
             return
         
         self.pub.publish(
-            observations(msg.camera_id, msg.image_counter, obser)
+            observations(msg.camera_id, msg.image_counter, obs)
         )
-        
-        
 
     def __init__(self):
         # Locked when self.detectors is altered or iterated

--- a/src/scripts/node_detector_control.py
+++ b/src/scripts/node_detector_control.py
@@ -86,7 +86,7 @@ class DetectorControlNode:
             return
         
         self.pub.publish(
-            observations(msg.camera_id, msg.image_counter, tuple(obser))
+            observations(msg.camera_id, msg.image_counter, obser)
         )
         
         

--- a/src/scripts/node_detector_control.py
+++ b/src/scripts/node_detector_control.py
@@ -2,7 +2,6 @@
 
 import time
 import threading
-from functools import reduce
 
 from node_object_detector import ObjectNode
 from node_qr_detector import QRReader
@@ -79,7 +78,12 @@ class DetectorControlNode:
         # Flatten observations for combined observations message
         obser = (obs for observations_mapobj in observations_mapobj for obs in observations_mapobj)
         
+        obser = tuple(obser)
 
+        # Dont publish empty observations
+        if not obser:
+            return
+        
         self.pub.publish(
             observations(msg.camera_id, msg.image_counter, tuple(obser))
         )

--- a/src/scripts/node_detector_control.py
+++ b/src/scripts/node_detector_control.py
@@ -55,7 +55,7 @@ class DetectorControlNode:
         # Get observations from all active nodes
         self.detect_lock.acquire()
         observations_mapobj =  map(
-            lambda node: tuple(node.receive_img(img)), self.detectors.values()
+            lambda node: node.receive_img(img), self.detectors.values()
         )
         self.detect_lock.release()
         
@@ -63,12 +63,13 @@ class DetectorControlNode:
         # If combining is off, each node publishes the results separately.
         if not self.combine:
             for obs in observations_mapobj:
+                obs = tuple(obs)
                 if not obs:
                     # Dont publish empty observations
                     continue
 
                 self.pub.publish(
-                    observations(msg.camera_id, msg.image_counter, tuple(obs))
+                    observations(msg.camera_id, msg.image_counter, obs)
                 )
             return
         

--- a/src/scripts/node_object_detector.py
+++ b/src/scripts/node_object_detector.py
@@ -123,18 +123,21 @@ class ObjectNode:
         self.last_detect = time.time()
         period = self.period
         # Convert the image back from an image message to a numpy ndarray
-        observation_list = []
-
-        for detection in self.detector.detect(img):
-            observation_list.append(
-                observation(
-                    self.name, detection["class_id"], detection["label"],
-                    detection["score"],
-                    boundingbox(detection["bbox"]["top"],
-                                detection["bbox"]["right"],
-                                detection["bbox"]["bottom"],
-                                detection["bbox"]["left"]), polygon(0, []),
-                    img.shape[0], img.shape[1]))
+        
+        observations_res = self.detector.detect(img)
+        observations_mapobj = map(lambda detection: observation(
+            self.name,
+            detection['class_id'],
+            detection['label'],
+            detection['score'],
+            boundingbox(detection['bbox']['top'],
+                        detection['bbox']['right'],
+                        detection['bbox']['bottom'],
+                        detection['bbox']['left']),
+            polygon(0, tuple()),
+            img.shape[0],
+            img.shape[1]
+        ), observations_res)
 
         processing_time = time.time() - self.last_detect
         if processing_time > period:
@@ -146,4 +149,4 @@ class ObjectNode:
         # Ready to detect the next image
         self.detect_lock.release()
 
-        return observation_list
+        return observations_mapobj

--- a/src/scripts/node_qr_detector.py
+++ b/src/scripts/node_qr_detector.py
@@ -84,19 +84,22 @@ class QRReader:
         period = self.period
 
         # Detect QR codes with qr_detector.py, save to list.
-        observation_list = []
-        for o in qr_detector.detect(img):
-            observation_list.append(
-                observation(
-                    name_det_qr, 0, str(o["data"]), 1,
-                    boundingbox(o["bbox"]["top"], o["bbox"]["right"],
-                                o["bbox"]["bottom"], o["bbox"]["left"]),
-                    polygon(len(o["polygon"]), [
-                        point64(o["polygon"][0]["x"], o["polygon"][0]["y"]),
-                        point64(o["polygon"][1]["x"], o["polygon"][1]["y"]),
-                        point64(o["polygon"][2]["x"], o["polygon"][2]["y"]),
-                        point64(o["polygon"][3]["x"], o["polygon"][3]["y"])
-                    ]), img.shape[0], img.shape[1]))
+        detections_res = qr_detector.detect(img)
+        observations_mapobj = map(lambda qr_code: observation(
+            self.name,
+            0,
+            str(qr_code['data']),
+            1,
+            boundingbox(qr_code['bbox']['top'],
+                        qr_code['bbox']['right'],
+                        qr_code['bbox']['bottom'],
+                        qr_code['bbox']['left']),
+            polygon(len(qr_code['polygon']),
+                    tuple(point64(p['x'], p['y']) for p in qr_code['polygon'])
+            ),
+            img.shape[0],
+            img.shape[1]
+        ), detections_res)
 
         processing_time = time.time() - self.last_detect
         if processing_time > period:
@@ -108,4 +111,4 @@ class QRReader:
         # Ready to detect the next image
         self.detect_lock.release()
 
-        return observation_list
+        return observations_mapobj


### PR DESCRIPTION
Nodejen listat korvattu iteraattoreilla. Aivan viimeisessä vaiheessa luodaan tupleja listojen sijaan. Samalla hieman muokattu node_detector_controll.py :n receive_img()-metodin iffejä. Tämä tehty 1) tehokkuuden parantamiseksi ja 2) sorttausta/filtteröintiä helpottamaan.